### PR TITLE
Add musl build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,13 +21,18 @@ jobs:
     strategy:
       fail-fast: false # don't fail other jobs if one fails
       matrix:
-        build: [x86_64-linux, aarch64-linux, x86_64-macos, x86_64-windows] #, x86_64-win-gnu, win32-msvc
+        build: [x86_64-linux, x86_64-linux-static, aarch64-linux, x86_64-macos, x86_64-windows] #, x86_64-win-gnu, win32-msvc
         include:
         - build: x86_64-linux
           os: ubuntu-20.04
           rust: stable
           target: x86_64-unknown-linux-gnu
           cross: false
+        - build: x86_64-linux-static
+          os: ubuntu-latest
+          rust: stable
+          target: x86_64-unknown-linux-musl
+          cross: true
         - build: aarch64-linux
           os: ubuntu-20.04
           rust: stable
@@ -69,20 +74,25 @@ jobs:
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
           override: true
+      
+      - name: Install crosscompile dependencies
+        if: matrix.build == 'x86_64-linux-static'
+        run: |
+          sudo apt-get install musl-tools
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.cross }}
           command: test
-          args: --release --locked --target ${{ matrix.target }}
+          args: --release --target ${{ matrix.target }}
 
       - name: Build release binary
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.cross }}
           command: build
-          args: --release --locked --target ${{ matrix.target }}
+          args: --release --target ${{ matrix.target }}
 
       - name: Strip release binary (linux and macos)
         if: matrix.build == 'x86_64-linux' || matrix.build == 'x86_64-macos'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,9 +49,4 @@ qrcode = "0.12.0"
 image = "0.23.14"
 glob = "0.3.0"
 serde_yaml = "0.8"
-
-[target.'cfg(all(target_arch="aarch64", target_vendor="unknown", target_os="linux", target_env="gnu"))'.dependencies]
 reqwest = { version = "0.11", default-features = false, features = ["json", "rustls-tls"] }
-
-[target.'cfg(not(all(target_arch="aarch64", target_vendor="unknown", target_os="linux", target_env="gnu")))'.dependencies]
-reqwest = { version = "0.11", features = ["json"] }


### PR DESCRIPTION
> https://github.com/ForgQi/biliup-rs/issues/16

添加 musl-tools 系统依赖, 并且去掉 reqwest 对 openssl 的依赖

编译结果在此 https://github.com/cxu-fork/biliup-rs/releases/tag/v0.1.4-2

没加 strip. 如果要加, 可以参考 https://github.com/messense/rust-musl-cross#strip-binaries

我修改的部分中, 这些操作可能造成不良影响: 
- 把 reqwest 全局换上 rustls-tls, 而没有针对 musl 的 target 单独安排
- 取消了 cargo build 的 lock 选项

这是因为我对 cargo 不熟悉, 不会更好的写法