### PR TITLE
验证及更新Cookie

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -37,6 +37,8 @@ struct Cli {
 enum Commands {
     /// 登录B站并保存登录信息在执行目录下
     Login,
+    /// 验证并刷新在执行目录下的登录信息
+    Renew,
     /// 上传视频
     Upload {
         // Optional name to operate on
@@ -127,6 +129,9 @@ pub async fn parse() -> Result<()> {
     match cli.command {
         Commands::Login => {
             login(client).await?;
+        }
+        Commands::Renew => {
+            renew(client).await?;
         }
         Commands::Upload {
             video_path,
@@ -247,6 +252,14 @@ async fn login(client: Client) -> Result<()> {
     let file = std::fs::File::create("cookies.json")?;
     serde_json::to_writer_pretty(&file, &info)?;
     println!("登录成功，数据保存在{:?}", file);
+    Ok(())
+}
+
+async fn renew(client: Client) -> Result<()> {
+    let file = std::fs::File::open("cookies.json")?;
+    let info = client.login_by_cookies_file(file).await?;
+    let file = std::fs::File::create("cookies.json")?;
+    serde_json::to_writer_pretty(&file, &info)?;
     Ok(())
 }
 


### PR DESCRIPTION
经过研究客户端，发现B站账号有如下的 OAuth2 API：

### 验证 Cookie

- 请求： `GET https://passport.bilibili.com/x/passport-login/oauth2/info`
- 参数：`"access_key", "actionKey", "appkey", "ts"`
- 响应：
```json
{
  "code": 0,
  "message": "0",
  "ttl": 1,
  "data": {
    "mid": "<user mid>",
    "access_token": "<current token>",
    "expires_in": 9787360,
    "refresh":true
  }
}
```
- 经过观察，如果 "refresh" 为 `true`，即使 token 还没过期，客户端也会进行更新。

### 更新 Cookie

- 请求： `POST https://passport.bilibili.com/x/passport-login/oauth2/refresh_token`
- 参数：`"access_key", "actionKey", "appkey", "refresh_token" "ts"`
- 响应：同 [LoginInfo](https://github.com/ForgQi/biliup-rs/blob/b7bef8e3cf9e53ca6d729a094524cf257fadc932/src/client.rs#L344)
- 使用的 "appkey" 必须和一开始登录时的保持一致。

### 目前进度和问题
我已经在 PR 里添加了以上两种请求的实现，但实际应用中发现了上面提到的 appkey 问题。比如我使用了二维码登录，更新时必须得用相同的 appkey。目前的代码里主要用了两套 appkey 和 appsec。可能的方案有两种，一种是两套都分别试一下；另一种是自行拓展一下 cookie 内容，额外记录用到的 appkey。这需要商量一下再决定，麻烦大佬看看！