### PR TITLE
重新调整 cookie 的 API 逻辑

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ USAGE:
     biliup.exe [OPTIONS] <SUBCOMMAND>
 
 OPTIONS:
-    -c, --cookie-file <COOKIE_FILE>    登录信息文件 [default: cookies.json]
+    -u, --user-cookie <COOKIE_FILE>    登录信息文件 [default: cookies.json]
     -h, --help                         Print help information
     -V, --version                      Print version information
 
@@ -77,10 +77,10 @@ SUBCOMMANDS:
 ```
 
 ### 多账号支持
-请在子命令**之前**通过 `-a` 或者 `--cookie-file` 参数传入 cookie 文件的路径（默认为当前目录下的 "cookies.json"）。例如：
+请在子命令**之前**通过 `-u` 或者 `--user-cookie` 参数传入 cookie 文件的路径（默认为当前目录下的 "cookies.json"）。例如：
 ```shell
-$ biliup -a user1.json login
-$ biliup --cookie-file user2.json upload ...
+$ biliup -u user1.json login
+$ biliup --user-cookie user2.json upload ...
 $ biliup renew  # ./cookies.json
 ```
 

--- a/README.md
+++ b/README.md
@@ -77,9 +77,9 @@ SUBCOMMANDS:
 ```
 
 ### 多账号支持
-请在子命令**之前**通过 `-c` 或者 `--cookie-file` 参数传入 cookie 文件的路径（默认为当前目录下的 "cookies.json"）。例如：
+请在子命令**之前**通过 `-a` 或者 `--cookie-file` 参数传入 cookie 文件的路径（默认为当前目录下的 "cookies.json"）。例如：
 ```shell
-$ biliup -c user1.json login
+$ biliup -a user1.json login
 $ biliup --cookie-file user2.json upload ...
 $ biliup renew  # ./cookies.json
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ B 站命令行投稿工具，支持 **短信登录**，**账号密码登录**，
 
 [下载地址](https://github.com/ForgQi/biliup-rs/releases)
 
-## USEAGE
+## USAGE
 
 投稿支持**直接投稿**和对现有稿件**追加投稿**：
 * 快速投稿，输入 `biliup upload test1.mp4 test2.mp4` 即可快速多p投稿；
@@ -55,23 +55,33 @@ OPTIONS:
  
 * 查看完整用法命令行输入 `biliup -h`
 ```shell
-biliup 0.1.5
+biliup 0.1.8
 Upload video to bilibili.
 
 USAGE:
-    biliup.exe <SUBCOMMAND>
+    biliup.exe [OPTIONS] <SUBCOMMAND>
 
 OPTIONS:
-    -h, --help       Print help information
-    -V, --version    Print version information
+    -c, --cookie-file <COOKIE_FILE>    登录信息文件 [default: cookies.json]
+    -h, --help                         Print help information
+    -V, --version                      Print version information
 
 SUBCOMMANDS:
     append    是否要对某稿件追加视频
     help      Print this message or the help of the given subcommand(s)
-    login     登录B站并保存登录信息在执行目录下
+    login     登录B站并保存登录信息
+    renew     手动验证并刷新登录信息
     show      打印视频详情
     upload    上传视频
 
+```
+
+### 多账号支持
+请在子命令**之前**通过 `-c` 或者 `--cookie-file` 参数传入 cookie 文件的路径（默认为当前目录下的 "cookies.json"）。例如：
+```shell
+$ biliup -c user1.json login
+$ biliup --cookie-file user2.json upload ...
+$ biliup renew  # ./cookies.json
 ```
 
 ### Windows 演示

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,7 +33,7 @@ struct Cli {
     command: Commands,
 
     /// 登录信息文件
-    #[clap(short, long, default_value = "cookies.json")]
+    #[clap(short = 'a', long, default_value = "cookies.json")]
     cookie_file: PathBuf,
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -93,6 +93,7 @@ impl Client {
         if oauth_info.refresh {
             let new_info = self.renew_tokens(login_info).await?;
             file.rewind()?;
+            file.set_len(0)?;
             serde_json::to_writer_pretty(std::io::BufWriter::new(&file), &new_info)?;
             Ok(new_info)
         } else {


### PR DESCRIPTION
不好意思，经过实际使用发现 #23 设计的 API 有些问题。目前的设计不方便按需检测 cookie 更新并重新写入文件。因此我重新考虑并对此做了修改。

- 回滚了 #23 的新增 API，我发现传入字符串反而会让更新过程变得更难于管理，还是使用文件能更好地保证一致性。
- 通过 cookie 登录的逻辑调整为如果要 refresh，就更新 cookie 并**自动**写入回原来的文件。
- 添加了自定义 cookie 文件路径的命令行参数，如果不指定默认为 "cookies.json"。

### 使用举例
- 登录并将信息存储在 "user1.json"：
```shell
$ biliup -c user1.json login
```
- 使用 "user2.json" 里的信息登录并上传视频：
```shell
$ biliup -c user2.json upload ...
```