### PR TITLE
优化 append 相关的 API

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -206,18 +206,7 @@ pub async fn parse() -> Result<()> {
                 .await?;
             // studio.aid = Option::from(avid);
             let mut uploaded_videos = upload(&video_path, &client, line, limit).await?;
-            let mut video_info = BiliBili::new(&login_info, &client).video_data(vid).await?;
-            let mut studio: Studio = serde_json::from_value(video_info["archive"].take())?;
-            studio.videos = video_info["videos"]
-                .as_array()
-                .unwrap()
-                .iter()
-                .map(|v| Video {
-                    desc: v["desc"].as_str().unwrap().to_string(),
-                    filename: v["filename"].as_str().unwrap().to_string(),
-                    title: v["title"].as_str().map(|t| t.to_string()),
-                })
-                .collect();
+            let mut studio = BiliBili::new(&login_info, &client).studio_data(vid).await?;
             // studio.video_data(&login_info).await?;
             studio.videos.append(&mut uploaded_videos);
             studio.edit(&login_info).await?;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -198,16 +198,14 @@ pub async fn parse() -> Result<()> {
             vid,
             line,
             limit,
-            mut studio,
+            studio: _,
         } if !video_path.is_empty() => {
             println!("number of concurrent futures: {limit}");
             let login_info = client
                 .login_by_cookies(fopen_rw(cli.user_cookie)?)
                 .await?;
-            // studio.aid = Option::from(avid);
             let mut uploaded_videos = upload(&video_path, &client, line, limit).await?;
             let mut studio = BiliBili::new(&login_info, &client).studio_data(vid).await?;
-            // studio.video_data(&login_info).await?;
             studio.videos.append(&mut uploaded_videos);
             studio.edit(&login_info).await?;
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, bail, Result};
 use base64::encode;
 use cookie::Cookie;
 // use futures_util::AsyncWriteExt;

--- a/src/video.rs
+++ b/src/video.rs
@@ -251,6 +251,16 @@ impl BiliBili<'_, '_> {
         }
     }
 
+    pub async fn studio_data(&self, vid: Vid) -> Result<Studio> {
+        let mut video_info = self.video_data(vid).await?;
+
+        let mut studio: Studio = serde_json::from_value(video_info["archive"].take())?;
+        let videos: Vec<Video> = serde_json::from_value(video_info["videos"].take())?;
+
+        studio.videos = videos;
+        Ok(studio)
+    }
+
     pub async fn archive_pre(&self) -> Result<Value> {
         Ok(self
             .client

--- a/src/video.rs
+++ b/src/video.rs
@@ -1,7 +1,6 @@
-use crate::client::{Client, LoginInfo, ResponseData, ResponseValue};
+use crate::client::{Client, LoginInfo};
 use crate::error::CustomError;
 use anyhow::{anyhow, bail, Result};
-use reqwest::header::HeaderValue;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::fmt::{Display, Formatter};
@@ -298,7 +297,7 @@ impl BiliBili<'_, '_> {
         };
 
         if let Response {
-            code,
+            code: _,
             data: Some(value),
             ..
         } = res


### PR DESCRIPTION
目前的 append 实现里需要手写对 video_info 的解析，合并 studio 和 videos。在作为库调用的时候不够方便，几乎需要整体 copy 这部分代码。因此我对这个步骤进行了封装，添加了 studio_data 方法，可以直接返回设置好 videos 的 studio。

此外根据 cargo check 时的 warning 整理了一下代码，解决了一些 unused import 和 dead code。