### PR TITLE
添加 ARM Mac 平台的 Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false # don't fail other jobs if one fails
       matrix:
-        build: [x86_64-linux, x86_64-linux-musl, aarch64-linux, x86_64-macos, x86_64-windows] #, x86_64-win-gnu, win32-msvc
+        build: [x86_64-linux, x86_64-linux-musl, aarch64-linux, x86_64-macos, x86_64-windows, aarch64-macos] #, x86_64-win-gnu, win32-msvc
         include:
         - build: x86_64-linux
           os: ubuntu-20.04
@@ -48,10 +48,11 @@ jobs:
           rust: stable
           target: x86_64-pc-windows-msvc
           cross: false
-#        - build: aarch64-macos
-#          os: macos-latest
-#          rust: stable
-#          target: aarch64-apple-darwin
+        - build: aarch64-macos
+          os: macos-latest
+          rust: stable
+          target: aarch64-apple-darwin
+          cross: false
         # - build: x86_64-win-gnu
         #   os: windows-2019
         #   rust: stable-x86_64-gnu
@@ -76,6 +77,7 @@ jobs:
           override: true
 
       - name: Run cargo test
+        if: matrix.build != 'aarch64-macos'
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.cross }}


### PR DESCRIPTION
之前的 workflow 跑不通是因为 x86 的 Mac 无法运行 ARM 的二进制文件，导致 cargo test 失败。工具链本身是支持编译的，因此我简单直接地跳过了这个步骤，等以后 GitHub Actions 有了 ARM Mac 的运行环境再加回来。

运行结果可以看 <https://github.com/hguandl/biliup-rs/runs/6706882927>
编译产物在 <https://github.com/hguandl/biliup-rs/releases/tag/dev>

我的设备是 MacBook Pro (13-inch, M1, 2020)，biliupR-dev-aarch64-macos.tar.xz 里面的二进制文件可以正常运行，这个编译应该没什么问题。